### PR TITLE
CacheFilter: added handling of range requests.

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -120,6 +120,7 @@ public:
   const LowerCaseString ClientTraceId{"x-client-trace-id"};
   const LowerCaseString Connection{"connection"};
   const LowerCaseString ContentLength{"content-length"};
+  const LowerCaseString ContentRange{"content-range"};
   const LowerCaseString ContentType{"content-type"};
   const LowerCaseString Cookie{"cookie"};
   const LowerCaseString Date{"date"};

--- a/source/extensions/filters/http/cache/cache_filter.cc
+++ b/source/extensions/filters/http/cache/cache_filter.cc
@@ -4,6 +4,7 @@
 
 #include "extensions/filters/http/cache/cache_filter_utils.h"
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -82,8 +83,7 @@ void CacheFilter::onHeaders(LookupResult&& result) {
   switch (result.cache_entry_status_) {
   case CacheEntryStatus::RequiresValidation:
   case CacheEntryStatus::FoundNotModified:
-  case CacheEntryStatus::NotSatisfiableRange: // TODO(#10132): create 416 response.
-    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;          // We don't yet return or support these codes.
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE; // We don't yet return or support these codes.
   case CacheEntryStatus::Unusable:
     if (state_ == GetHeadersState::FinishedGetHeadersCall) {
       // decodeHeader returned Http::FilterHeadersStatus::StopAllIterationAndWatermark--restart it
@@ -93,8 +93,29 @@ void CacheFilter::onHeaders(LookupResult&& result) {
       state_ = GetHeadersState::GetHeadersResultUnusable;
     }
     return;
-  case CacheEntryStatus::SatisfiableRange: // TODO(#10132): break response content to the ranges
-                                           // requested.
+  case CacheEntryStatus::NotSatisfiableRange:
+    result.headers_->setStatus(static_cast<uint64_t>(Http::Code::RangeNotSatisfiable));
+    result.headers_->setContentLength(0);
+    result.headers_->addCopy(Http::Headers::get().ContentRange,
+                             absl::StrCat("bytes */", result.content_length_));
+    result.content_length_ = 0;
+  case CacheEntryStatus::SatisfiableRange:
+    // Multi-part responses are not supported; they will be treated as usual 200 response on '::Ok'
+    // case below. A possible way to achieve that would be to move all ranges to remaining_body, and
+    // add logic inside '::onBody' to interleave the body bytes with sub-headers and separator
+    // string for each part. Would need to keep track if the current range is over or not to know
+    // when to insert the separator, and calculate the length based on length of ranges + extra
+    // headers and separators.
+    if (result.response_ranges_.size() == 1) {
+      remaining_body_ = std::move(result.response_ranges_);
+      result.headers_->setStatus(static_cast<uint64_t>(Http::Code::PartialContent));
+      result.headers_->setContentLength(remaining_body_[0].length());
+      result.headers_->addCopy(Http::Headers::get().ContentRange,
+                               absl::StrCat("bytes ", remaining_body_[0].begin(), "-",
+                                            remaining_body_[0].end() - 1, "/",
+                                            result.content_length_));
+      result.content_length_ = remaining_body_[0].length();
+    }
   case CacheEntryStatus::Ok:
     response_has_trailers_ = result.has_trailers_;
     const bool end_stream = (result.content_length_ == 0 && !response_has_trailers_);
@@ -109,7 +130,10 @@ void CacheFilter::onHeaders(LookupResult&& result) {
       return;
     }
     if (result.content_length_ > 0) {
-      remaining_body_.emplace_back(0, result.content_length_);
+      if (remaining_body_.empty()) {
+        // no range was added to remaining_body_, will add entire body to response
+        remaining_body_.emplace_back(0, result.content_length_);
+      }
       getBody();
     } else {
       lookup_->getTrailers(

--- a/source/extensions/filters/http/cache/http_cache.cc
+++ b/source/extensions/filters/http/cache/http_cache.cc
@@ -69,8 +69,9 @@ LookupRequest::LookupRequest(const Http::RequestHeaderMap& request_headers, Syst
   // TODO(toddmgreer): handle the resultant vector<AdjustedByteRange> in CacheFilter::onOkHeaders.
   // Range Requests are only valid for GET requests
   if (request_headers.getMethodValue() == Http::Headers::get().MethodValues.Get) {
-    // TODO(cbdm): using a constant limit of 10 ranges, could make this into a parameter
-    const int RangeSpecifierLimit = 10;
+    // TODO(cbdm): using a constant limit of 1 range since we don't support multi-part responses nor
+    // coalesce multiple overlapping ranges. Could make this into a parameter based on config.
+    const int RangeSpecifierLimit = 1;
     request_range_spec_ = RangeRequests::parseRanges(request_headers, RangeSpecifierLimit);
   }
   key_.set_cluster_name("cluster_name_goes_here");
@@ -112,7 +113,6 @@ LookupResult LookupRequest::makeLookupResult(Http::ResponseHeaderMapPtr&& respon
   result.headers_ = std::move(response_headers);
   result.content_length_ = content_length;
   if (!adjustByteRangeSet(result.response_ranges_, request_range_spec_, content_length)) {
-    result.headers_->setStatus(static_cast<uint64_t>(Http::Code::RangeNotSatisfiable));
     result.cache_entry_status_ = CacheEntryStatus::NotSatisfiableRange;
   } else if (!result.response_ranges_.empty()) {
     result.cache_entry_status_ = CacheEntryStatus::SatisfiableRange;

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -170,10 +170,10 @@ TEST_F(LookupRequestTest, NotExpiredViaFallbackheader) {
   EXPECT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
 }
 
-TEST_F(LookupRequestTest, SatisfiableRange) {
+TEST_F(LookupRequestTest, SingleSatisfiableRange) {
   // add method (GET) and range to headers
   request_headers_.addReference(Http::Headers::get().Method, Http::Headers::get().MethodValues.Get);
-  request_headers_.addReference(Http::Headers::get().Range, "bytes=1-99,3-,-2");
+  request_headers_.addReference(Http::Headers::get().Range, "bytes=1-99");
 
   const LookupRequest lookup_request(request_headers_, current_time_);
 
@@ -191,27 +191,50 @@ TEST_F(LookupRequestTest, SatisfiableRange) {
   EXPECT_EQ(lookup_response.content_length_, 4);
 
   // checks that the ranges have been adjusted to the content's length
-  EXPECT_EQ(lookup_response.response_ranges_.size(), 3);
+  EXPECT_EQ(lookup_response.response_ranges_.size(), 1);
 
   EXPECT_EQ(lookup_response.response_ranges_[0].begin(), 1);
   EXPECT_EQ(lookup_response.response_ranges_[0].end(), 4);
   EXPECT_EQ(lookup_response.response_ranges_[0].length(), 3);
 
-  EXPECT_EQ(lookup_response.response_ranges_[1].begin(), 3);
-  EXPECT_EQ(lookup_response.response_ranges_[1].end(), 4);
-  EXPECT_EQ(lookup_response.response_ranges_[1].length(), 1);
+  EXPECT_FALSE(lookup_response.has_trailers_);
+}
 
-  EXPECT_EQ(lookup_response.response_ranges_[2].begin(), 2);
-  EXPECT_EQ(lookup_response.response_ranges_[2].end(), 4);
-  EXPECT_EQ(lookup_response.response_ranges_[2].length(), 2);
+TEST_F(LookupRequestTest, MultipleSatisfiableRanges) {
+  // add method (GET) and range to headers
+  request_headers_.addCopy(Http::Headers::get().Method.get(),
+                           Http::Headers::get().MethodValues.Get);
+  request_headers_.addCopy(Http::Headers::get().Range.get(), "bytes=1-99,3-,-3");
 
+  const LookupRequest lookup_request(request_headers_, current_time_);
+
+  const Http::TestResponseHeaderMapImpl response_headers(
+      {{"date", formatter_.fromTime(current_time_)},
+       {"cache-control", "public, max-age=3600"},
+       {"content-length", "4"}});
+  const uint64_t content_length = 4;
+  const LookupResult lookup_response =
+      makeLookupResult(lookup_request, response_headers, content_length);
+
+  // Because we do not support multi-part responses for now, we are limiting parsing of a single
+  // range. Thus, multiple ranges are ignored, and a usual "::Ok" should be expected. If multi-part
+  // responses are implemented (and the parsing limit is changed), this test should be adjusted.
+
+  ASSERT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
+
+  ASSERT_TRUE(lookup_response.headers_);
+  EXPECT_THAT(*lookup_response.headers_, Http::IsSupersetOfHeaders(response_headers));
+  EXPECT_EQ(lookup_response.content_length_, 4);
+
+  // Check that the ranges have been ignored since we don't support multi-part responses.
+  EXPECT_EQ(lookup_response.response_ranges_.size(), 0);
   EXPECT_FALSE(lookup_response.has_trailers_);
 }
 
 TEST_F(LookupRequestTest, NotSatisfiableRange) {
   // add method (GET) and range headers
   request_headers_.addReference(Http::Headers::get().Method, Http::Headers::get().MethodValues.Get);
-  request_headers_.addReference(Http::Headers::get().Range, "bytes=5-99,100-");
+  request_headers_.addReference(Http::Headers::get().Range, "bytes=100-");
 
   const LookupRequest lookup_request(request_headers_, current_time_);
 


### PR DESCRIPTION
Commit Message: CacheFilter: added handling of range requests.

Signed-off-by: Caio <caiomelo@google.com>

Additional Description:
Follow-up to PR envoyproxy#11943. Implements the handling of range requests in the cache filter; when a request has a range request, the response will contain only the appropriate range instead of the entire body.

Risk Level: Low
Testing: Unit testing
Docs Changes: N/A
Release Notes: N/A
Fixes #10132